### PR TITLE
Fixes #2. Convert exceptions to error events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ $ npm test
 
 * 1.1.1
 	+ Setup coffee-script for development
+	+ createReadStream/createWriteStream send error events instead of exceptions
 
 * 1.1.0
 	+ Added support for windows file systems

--- a/test/src/fs.posix.coffee
+++ b/test/src/fs.posix.coffee
@@ -1072,8 +1072,11 @@ describe 'fs.posix', ->
 
 	describe '#createReadStream()', ->
 
-		it 'should return an error if file does not exists', ->
-			expect( -> fs.createReadStream('/var/www/index.php') ).to.throw(Error, "File or directory '/var/www/index.php' does not exists.")
+		it 'should emit an error event if file does not exist', (done) ->
+			rs = fs.createReadStream('/var/www/index.php')
+			rs.on 'error', (err) ->
+				expect(err).to.be.an.instanceof(Error)
+				done()
 
 		it 'should create readable stream', (done) ->
 			fs.writeFileSync('/var/www/index.php', 'hello word')
@@ -1101,8 +1104,20 @@ describe 'fs.posix', ->
 
 	describe '#createWriteStream()', ->
 
-		it 'should return an error if file does not exists', ->
-			expect( -> fs.createReadStream('/var/www/index.php') ).to.throw(Error, "File or directory '/var/www/index.php' does not exists.")
+		it 'should emit an error event if mode is wx and file already exists', (done) ->
+			fs.writeFileSync('/var/www/index.php', '')
+			ws = fs.createWriteStream('/var/www/index.php', {flags: 'wx'})
+			ws.on 'error', (err) ->
+				expect(err).to.be.an.instanceof(Error)
+				done()
+
+		it 'should emit an error event if file is a directory', (done) ->
+			fs.mkdirSync('/var/www')
+			ws = fs.createWriteStream('/var/www')
+			ws.on 'error', (err) ->
+				expect(err).to.be.an.instanceof(Error)
+				done()
+			ws.write('hello')
 
 		it 'should create writable stream', (done) ->
 			fs.writeFileSync('/var/www/index.php', '')

--- a/test/src/fs.windows.coffee
+++ b/test/src/fs.windows.coffee
@@ -1102,8 +1102,11 @@ describe 'fs.windows', ->
 
 	describe '#createReadStream()', ->
 
-		it 'should return an error if file does not exists', ->
-			expect( -> fs.createReadStream('c:\\xampp\\htdocs\\index.php') ).to.throw(Error, "File or directory 'c:\\xampp\\htdocs\\index.php' does not exists.")
+		it 'should emit an error event if file does not exist', (done) ->
+			rs = fs.createReadStream('c:\\xampp\\htdocs\\index.php')
+			rs.on 'error', (err) ->
+				expect(err).to.be.an.instanceof(Error)
+				done()
 
 		it 'should create readable stream', (done) ->
 			fs.writeFileSync('c:\\xampp\\htdocs\\index.php', 'hello word')
@@ -1131,8 +1134,20 @@ describe 'fs.windows', ->
 
 	describe '#createWriteStream()', ->
 
-		it 'should return an error if file does not exists', ->
-			expect( -> fs.createReadStream('c:\\xampp\\htdocs\\index.php') ).to.throw(Error, "File or directory 'c:\\xampp\\htdocs\\index.php' does not exists.")
+		it 'should emit an error event if mode is wx and file already exists', (done) ->
+			fs.writeFileSync('c:\\xampp\\htdocs\\index.php', '')
+			ws = fs.createWriteStream('c:\\xampp\\htdocs\\index.php', {flags: 'wx'})
+			ws.on 'error', (err) ->
+				expect(err).to.be.an.instanceof(Error)
+				done()
+
+		it 'should emit an error event if file is a directory', (done) ->
+			fs.mkdirSync('c:\\xampp\\htdocs')
+			ws = fs.createWriteStream('c:\\xampp\\htdocs')
+			ws.on 'error', (err) ->
+				expect(err).to.be.an.instanceof(Error)
+				done()
+			ws.write('hello')
 
 		it 'should create writable stream', (done) ->
 			fs.writeFileSync('c:\\xampp\\htdocs\\index.php', '')


### PR DESCRIPTION
I converted the createReadStream/createWriteStream exceptions into error events to match the original Node fs module. I converted the tests to check for this. I tried to make the code look like normal CoffeeScript, but I'm pretty new to it so I may have missed something. Let me know if there's any changes you want me to make.
