### PR TITLE
Fix #5. Pass error to callback in _write.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ $ npm test
 
 ## Changelog
 
+* 1.1.2
+	+ Bug with createWriteStream sending improper 'finish' event
+
 * 1.1.1
 	+ Setup coffee-script for development
 	+ createReadStream/createWriteStream send error events instead of exceptions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "fs-mock",
 	"description": "Simple fs mock with posix and windows file system styles",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"author": {
 		"name": "David Kudera",
 		"email": "sakren@gmail.com"

--- a/src/fs.coffee
+++ b/src/fs.coffee
@@ -1123,12 +1123,8 @@ class fs
 				chunk = new Buffer(chunk)
 
 			@write(fd, chunk, 0, chunk.length, position, (err) ->
-				if err
-					process.nextTick ->
-						ws.emit('error', err)
-
 				position += chunk.length
-				next()
+				next(err)
 			)
 
 		ws.on 'finish', =>

--- a/test/src/fs.posix.coffee
+++ b/test/src/fs.posix.coffee
@@ -1124,6 +1124,18 @@ describe 'fs.posix', ->
 				expect(err).to.be.an.instanceof(Error)
 				done()
 
+		it 'should not emit an finish event when valid read stream is piped to invalid write stream', (done) ->
+			fs.mkdirSync('/var/www')
+			fs.writeFileSync('/var/www/index.php', 'hello')
+			rs = fs.createReadStream('/var/www/index.php')
+
+			ws = fs.createWriteStream('/var/www')
+			ws.on 'finish', ->
+				throw new Error("should not finish")
+			ws.on 'error', (err) ->
+				done()
+			rs.pipe(ws)
+
 		it 'should emit an error event if file is a directory', (done) ->
 			fs.mkdirSync('/var/www')
 			ws = fs.createWriteStream('/var/www')


### PR DESCRIPTION
This fixes a bug where the 'finish' event is improperly emitted from the
write stream when the write stream is invalid and should only emit an
'error' event.
