### PR TITLE
Fix #9. Emit 'open' event in createReadStream and createWriteStream.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ $ npm test
 
 ## Changelog
 
+* 1.1.3
+	+ Bug with createReadStream and createWriteStream not emitting 'open' event
+
 * 1.1.2
 	+ Bug with createWriteStream sending improper 'finish' event
 

--- a/src/fs.coffee
+++ b/src/fs.coffee
@@ -1076,6 +1076,9 @@ class fs
 			if options.fd == null
 				options.fd = @openSync(path, options.flags, options.mode)
 
+			process.nextTick ->
+				rs.emit('open', options.fd)
+
 			size = @fstatSync(options.fd).size
 
 			buffer = new Buffer(size)
@@ -1112,6 +1115,8 @@ class fs
 
 		try
 			fd = @openSync(path, options.flags, options.mode)
+			process.nextTick ->
+				ws.emit('open', fd)
 		catch err
 			process.nextTick ->
 				ws.emit('error', err)

--- a/test/src/fs.posix.coffee
+++ b/test/src/fs.posix.coffee
@@ -1072,6 +1072,20 @@ describe 'fs.posix', ->
 
 	describe '#createReadStream()', ->
 
+		it 'should emit an open event with the file descriptor when it opens a file', (done) ->
+			fs.writeFileSync('/var/www/index.php', '')
+			rs = fs.createReadStream('/var/www/index.php')
+			rs.on 'open', (fd) ->
+				expect(fd).to.be.a('number')
+				done()
+
+		it 'should not emit an open event if file does not exist', (done) ->
+			rs = fs.createReadStream('/var/www/index.php')
+			rs.on 'open', (fd) ->
+				expect().fail()
+			rs.on 'error', (err) ->
+				done()
+
 		it 'should emit an error event if file does not exist', (done) ->
 			rs = fs.createReadStream('/var/www/index.php')
 			rs.on 'error', (err) ->
@@ -1116,6 +1130,21 @@ describe 'fs.posix', ->
 
 
 	describe '#createWriteStream()', ->
+
+		it 'should emit an open event with the file descriptor when it opens a file', (done) ->
+			fs.writeFileSync('/var/www/index.php', '')
+			ws = fs.createWriteStream('/var/www/index.php')
+			ws.on 'open', (fd) ->
+				expect(fd).to.be.a('number')
+				done()
+
+		it 'should not emit an open event if creating write stream fails', (done) ->
+			fs.writeFileSync('/var/www/index.php', '')
+			ws = fs.createWriteStream('/var/www/index.php', {flags: 'wx'})
+			ws.on 'open', (fd) ->
+				expect().fail()
+			ws.on 'error', (err) ->
+				done()
 
 		it 'should emit an error event if mode is wx and file already exists', (done) ->
 			fs.writeFileSync('/var/www/index.php', '')

--- a/test/src/fs.windows.coffee
+++ b/test/src/fs.windows.coffee
@@ -1102,6 +1102,20 @@ describe 'fs.windows', ->
 
 	describe '#createReadStream()', ->
 
+		it 'should emit an open event with the file descriptor when it opens a file', (done) ->
+			fs.writeFileSync('c:\\xampp\\htdocs\\index.php', '')
+			rs = fs.createReadStream('c:\\xampp\\htdocs\\index.php')
+			rs.on 'open', (fd) ->
+				expect(fd).to.be.a('number')
+				done()
+
+		it 'should not emit an open event if file does not exist', (done) ->
+			rs = fs.createReadStream('c:\\xampp\\htdocs\\index.php')
+			rs.on 'open', (fd) ->
+				expect().fail()
+			rs.on 'error', (err) ->
+				done()
+
 		it 'should emit an error event if file does not exist', (done) ->
 			rs = fs.createReadStream('c:\\xampp\\htdocs\\index.php')
 			rs.on 'error', (err) ->
@@ -1146,6 +1160,21 @@ describe 'fs.windows', ->
 
 
 	describe '#createWriteStream()', ->
+
+		it 'should emit an open event with the file descriptor when it opens a file', (done) ->
+			fs.writeFileSync('c:\\xampp\\htdocs\\index.php', '')
+			ws = fs.createWriteStream('/var/www/index.php')
+			ws.on 'open', (fd) ->
+				expect(fd).to.be.a('number')
+				done()
+
+		it 'should not emit an open event if creating write stream fails', (done) ->
+			fs.writeFileSync('c:\\xampp\\htdocs\\index.php', '')
+			ws = fs.createWriteStream('c:\\xampp\\htdocs\\index.php', {flags: 'wx'})
+			ws.on 'open', (fd) ->
+				expect().fail()
+			ws.on 'error', (err) ->
+				done()
 
 		it 'should emit an error event if mode is wx and file already exists', (done) ->
 			fs.writeFileSync('c:\\xampp\\htdocs\\index.php', '')


### PR DESCRIPTION
This fixes a bug where the 'open' event was not emitted from createReadStream and createWriteStream when they were opened.